### PR TITLE
Fix occasional overflows in `add_mat_line()`

### DIFF
--- a/src/inner.rs
+++ b/src/inner.rs
@@ -410,15 +410,18 @@ pub fn add_mat_line(
     jinc: usize,
     nmat: usize,
 ) {
-    let mut k: usize = 0;
-    if let (Some(jj),) = (jj,) {
-        let joff: usize = (j + 5 - jj + nmat) % nmat;
-        v[jj] += x;
-        while k <= jinc {
-            m[jj].a[joff + k] += y * derivs[k];
-            k += 1
-        }
+    let Some(mut jj) = jj else { return };
+    jj %= nmat;
+    // At this point we know that `0 <= jj < nmat`, which is enough for us to avoid overflows.
+    let joff = match nmat {
+        ..=5 => j + 5 - jj,
+        6 => 2 + (nmat - jj + j + 3) % nmat,
+        7.. => (nmat - jj + j + 5) % nmat,
     };
+    v[jj] += x;
+    for k in 0..=jinc {
+        m[jj].a[joff + k] += y * derivs[k];
+    }
 }
 
 /// Computes the outer loop of the Newton iteration

--- a/tests/run_spiro.rs
+++ b/tests/run_spiro.rs
@@ -1,11 +1,36 @@
 #[macro_use]
 mod data;
 
-use spiro::*;
+use spiro::{SpiroCpTy::*, *};
 
 #[test]
 fn test() {
     let mut path = test_data!();
     let oplist = run_spiro(&mut path);
-    eprintln!("{:?}", oplist);
+    eprintln!("{oplist:?}");
+}
+
+#[test]
+fn add_mat_line_no_index_out_of_bounds() {
+    let mut path = test_data!();
+    path.insert(path.len() - 2, SpiroCP { ty: End, ..path[0] });
+    let oplist = run_spiro(&mut path);
+    eprintln!("{oplist:?}");
+}
+
+#[test]
+fn add_mat_line_no_underflow() {
+    let mut path = test_data!();
+    path.drain(..2);
+    let oplist = run_spiro(&mut path);
+    eprintln!("{oplist:?}");
+}
+
+#[test]
+fn add_mat_line_no_underflow_abrupt_end() {
+    let mut path = test_data!();
+    path.reverse();
+    path.insert(1, SpiroCP { ty: End, ..path[0] });
+    let oplist = run_spiro(&mut path);
+    eprintln!("{oplist:?}");
 }


### PR DESCRIPTION
It'd be nice if @lynzrand can additionally provide a regression test against this case.

The original function was:

https://github.com/fontforge/libspiro/blob/a2f38e13e32f6ba54a2647515cdd6d0a61228317/spiro.c#L781-L802

PS: I'm not entirely sure why `0..jinc` has been changed to `0..=jinc` in https://github.com/MFEK/spiro.rlib/commit/e867751c3e2d80605d42d575841ea3d47212f503. However reverting that change will break our E2E tests, so I'm not doing the reversion at least for now.